### PR TITLE
Get the element value, not just if the node exists

### DIFF
--- a/mammoth/docx/body_xml.py
+++ b/mammoth/docx/body_xml.py
@@ -73,13 +73,7 @@ def _create_reader(numbering, content_types, relationships, styles, docx_file, f
         return _success(documents.Text(_inner_text(element)))
    
     def element_or_value(element):
-        if element and ("w:val" in element.attributes):
-            element_value = element.attributes["w:val"]
-            if element_value == "false":
-                return False
-            elif element_value == "true":
-                return True
-        return element
+        return element and element.attributes.get("w:val") != "false"
 
     def run(element):
         properties = element.find_child_or_null("w:rPr")

--- a/mammoth/docx/body_xml.py
+++ b/mammoth/docx/body_xml.py
@@ -75,9 +75,9 @@ def _create_reader(numbering, content_types, relationships, styles, docx_file, f
     def element_or_value(element):
         if element and ("w:val" in element.attributes):
             element_value = element.attributes["w:val"]
-            if element_value == 'false':
+            if element_value == "false":
                 return False
-            elif element_value == 'true':
+            elif element_value == "true":
                 return True
         return element
 

--- a/tests/docx/body_xml_tests.py
+++ b/tests/docx/body_xml_tests.py
@@ -174,10 +174,20 @@ class ReadXmlElementTests(object):
     def run_is_not_struckthrough_if_strikethrough_element_is_not_present(self):
         run = self._read_run_with_properties([])
         assert_equal(False, run.is_strikethrough)
+        
+    @istest
+    def run_is_not_struckthrough_if_strikethrough_element_is_present_and_false(self):
+        run = self._read_run_with_properties([xml_element("w:strike", {"w:val": "false"})])
+        assert_equal(False, run.is_strikethrough)
     
     @istest
     def run_is_struckthrough_if_strikethrough_element_is_present(self):
         run = self._read_run_with_properties([xml_element("w:strike")])
+        assert_equal(True, run.is_strikethrough)
+        
+    @istest
+    def run_is_struckthrough_if_strikethrough_element_is_present_and_true(self):
+        run = self._read_run_with_properties([xml_element("w:strike", {"w:val": "true"})])
         assert_equal(True, run.is_strikethrough)
     
     @istest


### PR DESCRIPTION
Hi,

Thank you for this awesome project.

I had an error where all the output was with strikethrough. After analyzing, it was only checking if the node 'strikethrough' exists, and not checking it value.

This pull request fix this
