### PR TITLE
Use xml.sax.saxutils.escape instead of deprecated cgi.escape

### DIFF
--- a/mammoth/writers/html.py
+++ b/mammoth/writers/html.py
@@ -1,8 +1,7 @@
 from __future__ import unicode_literals
+from xml.sax.saxutils import escape
 
 from .abc import Writer
-
-import cgi
 
 
 class HtmlWriter(Writer):
@@ -31,7 +30,7 @@ class HtmlWriter(Writer):
 
 
 def _escape_html(text):
-    return cgi.escape(text, quote=True)
+    return escape(text, {'"': "&quot;"})
 
 
 def _generate_attribute_string(attributes):


### PR DESCRIPTION
```
/usr/local/lib/python3.6/dist-packages/mammoth/writers/html.py:34: DeprecationWarning: cgi.escape is deprecated, use html.escape instead
  return cgi.escape(text, quote=True)
```

Ref: [Escaping HTML](https://wiki.python.org/moin/EscapingHtml) on Python wiki.