### PR TITLE
Convert break elements to \n in raw text

### DIFF
--- a/mammoth/raw_text.py
+++ b/mammoth/raw_text.py
@@ -8,5 +8,7 @@ def extract_raw_text_from_element(element):
         text = "".join(map(extract_raw_text_from_element, getattr(element, "children", [])))
         if isinstance(element, documents.Paragraph):
             return text + "\n\n"
+        if isinstance(element, documents.Break):
+            return text + "\n"
         else:
             return text

--- a/tests/raw_text_tests.py
+++ b/tests/raw_text_tests.py
@@ -8,6 +8,17 @@ from mammoth import documents
 def raw_text_of_text_element_is_value():
     assert_equal("Hello", extract_raw_text_from_element(documents.Text("Hello")))
 
+@istest
+def raw_text_of_line_break_element_is_newline():
+    assert_equal("\n", extract_raw_text_from_element(documents.line_break))
+
+@istest
+def raw_text_of_page_break_element_is_newline():
+    assert_equal("\n", extract_raw_text_from_element(documents.page_break))
+
+@istest
+def raw_text_of_column_break_element_is_newline():
+    assert_equal("\n", extract_raw_text_from_element(documents.column_break))
 
 @istest
 def raw_text_of_paragraph_is_terminated_with_newlines():


### PR DESCRIPTION
Convert line breaks to `\n` when converting to raw text. 

Since `documents.Paragraph` is converted `text + "\n\n"`, I'm thinking it might make sense to convert breaks to `\n`?