### PR TITLE
implement xml properties and html attributes for "transform" usage

### DIFF
--- a/mammoth/documents.py
+++ b/mammoth/documents.py
@@ -22,7 +22,8 @@ class Paragraph(HasChildren):
     numbering = cobble.field()
     alignment = cobble.field()
     indent = cobble.field()
-
+    xml_properties = cobble.field()
+    html_attributes = cobble.field()
 
 @cobble.data
 class ParagraphIndent(object):
@@ -53,7 +54,9 @@ class Run(HasChildren):
     vertical_alignment = cobble.field()
     font = cobble.field()
     font_size = cobble.field()
-
+    xml_properties = cobble.field()
+    html_attributes = cobble.field()
+    
 @cobble.data
 class Text(Element):
     value = cobble.field()
@@ -106,11 +109,12 @@ def document(children, notes=None, comments=None):
         comments = []
     return Document(children, notes, comments=comments)
 
-def paragraph(children, style_id=None, style_name=None, numbering=None, alignment=None, indent=None):
+def paragraph(children, style_id=None, style_name=None, numbering=None, alignment=None, indent=None, xml_properties=None, html_attributes=None):
     if indent is None:
         indent = paragraph_indent()
-
-    return Paragraph(children, style_id, style_name, numbering, alignment=alignment, indent=indent)
+    if html_attributes is None:
+        html_attributes = {}
+    return Paragraph(children, style_id, style_name, numbering, alignment=alignment, indent=indent, xml_properties=xml_properties, html_attributes=html_attributes)
 
 def paragraph_indent(start=None, end=None, first_line=None, hanging=None):
     return ParagraphIndent(start=start, end=end, first_line=first_line, hanging=hanging)
@@ -128,6 +132,8 @@ def run(
     vertical_alignment=None,
     font=None,
     font_size=None,
+    xml_properties=None,
+    html_attributes=None,
 ):
     if vertical_alignment is None:
         vertical_alignment = VerticalAlignment.baseline
@@ -144,6 +150,8 @@ def run(
         vertical_alignment=vertical_alignment,
         font=font,
         font_size=font_size,
+        xml_properties=xml_properties,
+        html_attributes=html_attributes or {},
     )
 
 class VerticalAlignment(object):


### PR DESCRIPTION
From https://github.com/zt50tz/python-mammoth/commit/302f55a861ebca4171ab3ae786f9df987c8edbbb

This allows to write transforms such as: https://github.com/zt50tz/python-mammoth/blob/master/recipes/html_attributes.py

See issue https://github.com/mwilliamson/python-mammoth/issues/63 (support for colour)