### PR TITLE
Add support for table cell background color.

### DIFF
--- a/mammoth/conversion.py
+++ b/mammoth/conversion.py
@@ -213,6 +213,8 @@ class _DocumentConverter(documents.element_visitor(args=1)):
             attributes["colspan"] = str(table_cell.colspan)
         if table_cell.rowspan != 1:
             attributes["rowspan"] = str(table_cell.rowspan)
+        if table_cell.fill_color:
+            attributes["style"] = f"background-color:#{table_cell.fill_color};"
         nodes = [html.force_write] + self._visit_all(table_cell.children, context)
         return [
             html.element(tag_name, attributes, nodes)

--- a/mammoth/documents.py
+++ b/mammoth/documents.py
@@ -77,6 +77,7 @@ class TableRow(HasChildren):
 class TableCell(HasChildren):
     colspan = cobble.field()
     rowspan = cobble.field()
+    fill_color = cobble.field()
 
 @cobble.data
 class Break(Element):
@@ -178,12 +179,12 @@ def table(children, style_id=None, style_name=None):
 def table_row(children, is_header=None):
     return TableRow(children=children, is_header=bool(is_header))
 
-def table_cell(children, colspan=None, rowspan=None):
+def table_cell(children, colspan=None, rowspan=None, fill_color=None):
     if colspan is None:
         colspan = 1
     if rowspan is None:
         rowspan = 1
-    return TableCell(children=children, colspan=colspan, rowspan=rowspan)
+    return TableCell(children=children, colspan=colspan, rowspan=rowspan, fill_color=fill_color)
 
 
 def numbering_level(level_index, is_ordered):

--- a/mammoth/docx/body_xml.py
+++ b/mammoth/docx/body_xml.py
@@ -318,7 +318,7 @@ def _create_reader(numbering, content_types, relationships, styles, docx_file, f
                 documents.table_cell(
                     children=children,
                     colspan=colspan,
-                    background=fill_color,
+                    fill_color=fill_color,
                 ),
                 _vmerge=read_vmerge(properties),
             ))

--- a/mammoth/docx/body_xml.py
+++ b/mammoth/docx/body_xml.py
@@ -309,11 +309,16 @@ def _create_reader(numbering, content_types, relationships, styles, docx_file, f
         else:
             colspan = int(gridspan)
 
+        fill_color = properties \
+            .find_child_or_null("w:shd") \
+            .attributes.get("w:fill")
+
         return _read_xml_elements(element.children) \
             .map(lambda children: _add_attrs(
                 documents.table_cell(
                     children=children,
-                    colspan=colspan
+                    colspan=colspan,
+                    background=fill_color,
                 ),
                 _vmerge=read_vmerge(properties),
             ))


### PR DESCRIPTION
<w:shd fill="RRGGBB"> element is converted to <td style="background-color:#RRGGBB;">.﻿
