### PR TITLE
Added the ability to modify alt text within convert_image function

### DIFF
--- a/mammoth/images.py
+++ b/mammoth/images.py
@@ -6,7 +6,7 @@ from . import html
 def img_element(func):
     def convert_image(image):
         attributes = func(image).copy()
-        if image.alt_text:
+        if image.alt_text and attributes.get("alt") is None:
             attributes["alt"] = image.alt_text
             
         return [html.element("img", attributes)]

--- a/mammoth/images.py
+++ b/mammoth/images.py
@@ -7,7 +7,7 @@ def img_element(func):
     def convert_image(image):
         attributes = func(image).copy()
         if image.alt_text and attributes.get("alt") is None:
-            attributes["alt"] = image.alt_text
+            attributes["alt"] = image.alt_text.replace("\n", " ")
             
         return [html.element("img", attributes)]
     

--- a/tests/images_tests.py
+++ b/tests/images_tests.py
@@ -1,4 +1,5 @@
 import io
+import base64
 
 from hamcrest import assert_that, contains, has_properties
 from nose.tools import istest

--- a/tests/images_tests.py
+++ b/tests/images_tests.py
@@ -47,7 +47,7 @@ def modifying_alt_text_during_conversion():
         open=lambda: io.BytesIO(image_bytes),
     )
     
-    result = mammoth.images.img_element(convert_image(image))
+    result = mammoth.images.img_element(convert_image)(image)
     
     assert_that(
         result, 
@@ -60,3 +60,5 @@ def modifying_alt_text_during_conversion():
                 ),
         )
     )
+
+modifying_alt_text_during_conversion()

--- a/tests/images_tests.py
+++ b/tests/images_tests.py
@@ -61,4 +61,3 @@ def modifying_alt_text_during_conversion():
         )
     )
 
-modifying_alt_text_during_conversion()

--- a/tests/images_tests.py
+++ b/tests/images_tests.py
@@ -61,3 +61,27 @@ def modifying_alt_text_during_conversion():
         )
     )
 
+
+@istest
+def stripping_newlines_during_conversion():
+    image_bytes = b"abc"
+    image = mammoth.documents.Image(
+        alt_text="""A picture containing text
+
+Description automatically generated""",
+        content_type="image/jpeg",
+        open=lambda: io.BytesIO(image_bytes),
+    )
+    result = mammoth.images.data_uri(image)
+
+    assert_that(
+        result,
+        contains(
+            has_properties(
+                attributes={
+                    "alt": "A picture containing text  Description automatically generated",
+                    "src": "data:image/jpeg;base64,YWJj"
+                }
+            ),
+        )
+    )

--- a/tests/images_tests.py
+++ b/tests/images_tests.py
@@ -36,6 +36,7 @@ def modifying_alt_text_during_conversion():
             alt_text = "alt text output test"
         
         return {
+            "alt": alt_text,
             "src": "data:{0};base64,{1}".format(image.content_type, encoded_src)
         }
 

--- a/tests/images_tests.py
+++ b/tests/images_tests.py
@@ -25,3 +25,36 @@ def data_uri_encodes_images_in_base64():
     assert_that(result, contains(
         has_properties(attributes={"src": "data:image/jpeg;base64,YWJj"}),
     ))
+
+
+@istest
+def modifying_alt_text_during_conversion():
+    def convert_image(image):
+        with image.open() as image_bytes:
+            encoded_src = base64.b64encode(image_bytes.read()).decode("ascii")
+            alt_text = "alt text output test"
+        
+        return {
+            "src": "data:{0};base64,{1}".format(image.content_type, encoded_src)
+        }
+
+    image_bytes = b"abc"
+    image = mammoth.documents.Image(
+        alt_text=None,
+        content_type="image/jpeg",
+        open=lambda: io.BytesIO(image_bytes),
+    )
+    
+    result = mammoth.images.img_element(convert_image(image))
+    
+    assert_that(
+        result, 
+        contains(
+            has_properties(
+                attributes={
+                    "alt": "alt text output test",
+                    "src": "data:image/jpeg;base64,YWJj"
+                    }
+                ),
+        )
+    )


### PR DESCRIPTION
Fix for issue #103 which I opened last year, forgot about and found my own issue when trying do the same thing again in another project.

- Modified the document alt text grabbing to remove new line characters.
- Added check for replacement alt text.
- Added a test to verify the alt text changing works.