### PR TITLE
Update numbering_xml.py

### DIFF
--- a/mammoth/docx/numbering_xml.py
+++ b/mammoth/docx/numbering_xml.py
@@ -44,7 +44,7 @@ def _read_abstract_num_levels(element):
 
 
 def _read_abstract_num_level(element):
-    level_index = element.attributes["w:ilvl"]
+    level_index = element.attributes.get("w:ilvl")
     num_fmt = element.find_child_or_null("w:numFmt").attributes.get("w:val")
     is_ordered = num_fmt != "bullet"
     paragraph_style_id = element.find_child_or_null("w:pStyle").attributes.get("w:val")


### PR DESCRIPTION
when doing 
level_index = element.attributes.get("w:ilvl")
unnumbered list will not have "w:ilvl" key, and will throw exceptions here.  Changed it to attributes.get("w:ilvl") to avoid this exception.

In general, pull requests are not currently accepted.

Please instead submit an issue if you find a bug or would like to request a feature.
