### PR TITLE
Numbering on numPr should take precedence over paragraph style numbering

### DIFF
--- a/mammoth/docx/body_xml.py
+++ b/mammoth/docx/body_xml.py
@@ -236,17 +236,17 @@ def _create_reader(numbering, content_types, relationships, styles, docx_file, f
         return results.warning("{0} style with ID {1} was referenced but not defined in the document".format(style_type, style_id))
 
     def _read_numbering_properties(paragraph_style_id, element):
+        num_id = element.find_child_or_null("w:numId").attributes.get("w:val")
+        level_index = element.find_child_or_null("w:ilvl").attributes.get("w:val")
+        if not (num_id is None or level_index is None):
+            return numbering.find_level(num_id, level_index)
+            
         if paragraph_style_id is not None:
             level = numbering.find_level_by_paragraph_style_id(paragraph_style_id)
             if level is not None:
                 return level
 
-        num_id = element.find_child_or_null("w:numId").attributes.get("w:val")
-        level_index = element.find_child_or_null("w:ilvl").attributes.get("w:val")
-        if num_id is None or level_index is None:
-            return None
-        else:
-            return numbering.find_level(num_id, level_index)
+        return None
 
     def _read_paragraph_indent(element):
         attributes = element.attributes

--- a/tests/docx/body_xml_tests.py
+++ b/tests/docx/body_xml_tests.py
@@ -105,7 +105,20 @@ class ParagraphTests(object):
         assert_equal("1", paragraph.numbering.level_index)
         assert_equal(True, paragraph.numbering.is_ordered)
 
-    def test_numbering_on_paragraph_style_takes_precedence_over_numpr(self):
+    def test_numbering_on_paragraph_style_takes_precedence_when_no_numPr_is_present(self):
+        properties_xml = xml_element("w:pPr", {}, [
+            xml_element("w:pStyle", {"w:val": "List"}),
+        ])
+        paragraph_xml = xml_element("w:p", {}, [properties_xml])
+
+        numbering = _NumberingMap(
+            levels_by_paragraph_style_id={"List": documents.numbering_level("1", True)}
+        )
+        paragraph = _read_and_get_document_xml_element(paragraph_xml, numbering=numbering)
+
+        assert_equal(True, paragraph.numbering.is_ordered)
+
+    def test_numbering_on_numPr_takes_precedence_over_paragraph_style(self):
         numbering_properties_xml = xml_element("w:numPr", {}, [
             xml_element("w:ilvl", {"w:val": "1"}),
             xml_element("w:numId", {"w:val": "42"}),
@@ -122,8 +135,8 @@ class ParagraphTests(object):
         )
         paragraph = _read_and_get_document_xml_element(paragraph_xml, numbering=numbering)
 
-        assert_equal(True, paragraph.numbering.is_ordered)
-
+        assert_equal(False, paragraph.numbering.is_ordered)
+        
     def test_numbering_properties_are_ignored_if_lvl_is_missing(self):
         paragraph_xml = self._paragraph_with_numbering_properties([
             xml_element("w:numId", {"w:val": "42"}),


### PR DESCRIPTION
This PR covers issue https://github.com/mwilliamson/python-mammoth/issues/141

Added the following tests :
- paragraphs with no numbering properties use the paragraph style numbering properties
- paragraphs with numbering properties use them even if the paragraph style is present