### PR TITLE
Update body_xml.py

### DIFF
--- a/mammoth/docx/body_xml.py
+++ b/mammoth/docx/body_xml.py
@@ -560,6 +560,7 @@ def _create_reader(numbering, content_types, relationships, styles, docx_file, f
         "w:drawing": read_child_elements,
         "v:group": read_child_elements,
         "v:rect": read_child_elements,
+        "v:oval": read_child_elements,
         "v:roundrect": read_child_elements,
         "v:shape": read_child_elements,
         "v:textbox": read_child_elements,


### PR DESCRIPTION
Support v:oval which is also part of openxml-3.0.0

Is there a reason why v:oval is not currently supported?

According to https://learn.microsoft.com/fil-ph/dotnet/api/documentformat.openxml.linq.v.oval?view=openxml-3.0.0 it is quite similar to v:rect, or am I missing something?

If this cannot be accepted is there a way to override it with current version of library?